### PR TITLE
Initial replacement of SLA with SOFA

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,3 +44,8 @@ $(ALIASES):
 
 clean-local:
 	-rm -f $(ALIASES)
+	-rm -rf autom4te.cache
+	-rm -f compile config.guess config.h config.log config.status libtool config.h.in config.h.in~ config.sub configure configure~ configure.scan autoscan.log Makefile Makefile.in include/Makefile.in include/Makefile src/Makefile.in src/Makefile missing COPYING ltmain.sh INSTALL install-sh depcomp aclocal.m4 m4/libtool.m4 m4/lt~obsolete.m4 m4/ltoptions.m4 m4/ltsugar.m4 m4/ltversion.m4 stamp-h1
+
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -27,18 +27,15 @@ AC_LANG_CPLUSPLUS
 AC_REQUIRE_CPP
 
 dnl headers
-AC_CHECK_HEADERS([pcrecpp.h], [], [AC_MSG_ERROR(missing header; please fix)])
+AC_CHECK_HEADERS([pcrecpp.h, sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
 
 AC_CHECK_HEADERS([stdlib.h float.h math.h sstream string fstream iostream], [], [AC_MSG_ERROR(missing header; please fix)])
 
-AC_CHECK_HEADERS([pcrecpp.h], [], [AC_MSG_ERROR(missing header; please fix)])
-
-AC_CHECK_HEADERS([sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
-
+AC_CHECK_HEADERS([pcrecpp.h, sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
 
 
 dnl libraries.
-dnl AC_CHECK_LIB([csla], [main], [], [AC_MSG_ERROR(cannot link to the sla C library)])
+AC_CHECK_LIB([sofa_c], [main], [], [AC_MSG_ERROR(cannot link to the sofa C library)])
 
 AC_CHECK_LIB([pcrecpp], [main], [], [AC_MSG_ERROR(cannot link to the pcrecpp library)])
 

--- a/configure.ac
+++ b/configure.ac
@@ -27,11 +27,11 @@ AC_LANG_CPLUSPLUS
 AC_REQUIRE_CPP
 
 dnl headers
-AC_CHECK_HEADERS([pcrecpp.h, sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
+AC_CHECK_HEADERS([pcrecpp.h sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
 
 AC_CHECK_HEADERS([stdlib.h float.h math.h sstream string fstream iostream], [], [AC_MSG_ERROR(missing header; please fix)])
 
-AC_CHECK_HEADERS([pcrecpp.h, sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
+AC_CHECK_HEADERS([pcrecpp.h sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
 
 
 dnl libraries.

--- a/configure.ac
+++ b/configure.ac
@@ -27,14 +27,18 @@ AC_LANG_CPLUSPLUS
 AC_REQUIRE_CPP
 
 dnl headers
-AC_CHECK_HEADERS([pcrecpp.h slalib.h], [], [AC_MSG_ERROR(missing header; please fix)])
+AC_CHECK_HEADERS([pcrecpp.h], [], [AC_MSG_ERROR(missing header; please fix)])
 
 AC_CHECK_HEADERS([stdlib.h float.h math.h sstream string fstream iostream], [], [AC_MSG_ERROR(missing header; please fix)])
 
-AC_CHECK_HEADERS([pcrecpp.h slalib.h], [], [AC_MSG_ERROR(missing header; please fix)])
+AC_CHECK_HEADERS([pcrecpp.h], [], [AC_MSG_ERROR(missing header; please fix)])
+
+AC_CHECK_HEADERS([sofa.h], [], [AC_MSG_ERROR(missing header; please fix)])
+
+
 
 dnl libraries.
-AC_CHECK_LIB([csla], [main], [], [AC_MSG_ERROR(cannot link to the sla C library)])
+dnl AC_CHECK_LIB([csla], [main], [], [AC_MSG_ERROR(cannot link to the sla C library)])
 
 AC_CHECK_LIB([pcrecpp], [main], [], [AC_MSG_ERROR(cannot link to the pcrecpp library)])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 dnl Initialise
-AC_INIT([subs], [2.1])
+AC_INIT([subs],[2.1])
 
 AC_CONFIG_SRCDIR([src/gauss.cc])
 
@@ -23,7 +23,7 @@ dnl Initialise libtool
 AC_PROG_LIBTOOL
 
 dnl Make C++ the default
-AC_LANG_CPLUSPLUS
+AC_LANG([C++])
 AC_REQUIRE_CPP
 
 dnl headers

--- a/doc/genrst.py
+++ b/doc/genrst.py
@@ -9,26 +9,25 @@ from 'source' and writes them out to 'dest'
 import os, sys
 
 if len(sys.argv) != 3:
-    print 'usage: genrst.py source dest'
+    print('usage: genrst.py source dest')
     exit(1)
 
 source, dest = sys.argv[1:]
 
 if not os.path.exists(source):
-    print 'Source =',source,'does not exist'
+    print('Source =', source,'does not exist')
     exit(1)
 
 if not dest.endswith('.rst'):
-    print 'Destination =',dest,'does not end with .rst'
+    print('Destination =', dest,'does not end with .rst')
     exit(1)
 
 out = False
-with open(source) as fin, open(dest,'w') as fout:
+with open(source) as fin, open(dest, 'w') as fout:
     for line in fin:
         if line.find('!!sphinx') > -1:
             out = not out
         elif out:
             fout.write(line)
 
-print source,'--->',dest
-
+print(source, '--->', dest)

--- a/include/trm/date.h
+++ b/include/trm/date.h
@@ -5,6 +5,9 @@
 #include <string>
 #include "trm/subs.h"
 
+// Define MJD0 as the 0 for the MJD system, i.e. 1858 Nov 17.5
+#define MJD0 2400000.5
+
 namespace Subs {
 
   //! Class for representing dates.

--- a/include/trm/date.h
+++ b/include/trm/date.h
@@ -56,7 +56,7 @@ namespace Subs {
     void date(int& day_, int& month_, int& year_) const;
 
     //! Returns the modified julian day number
-    int mjd() const;
+    double mjd() const;
 
     //! Returns a date string
     std::string str() const;

--- a/include/trm/date.h
+++ b/include/trm/date.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <string>
+#include "sofa.h"
 #include "trm/subs.h"
 
 // Define MJD0 as the 0 for the MJD system, i.e. 1858 Nov 17.5

--- a/include/trm/date.h
+++ b/include/trm/date.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <string>
-#include "sofa.h"
+#include <sofa.h>
 #include "trm/subs.h"
 
 // Define MJD0 as the 0 for the MJD system, i.e. 1858 Nov 17.5

--- a/include/trm/position.h
+++ b/include/trm/position.h
@@ -3,7 +3,7 @@
 
 #include <cmath>
 #include <string>
-#include "sofa.h"
+#include <sofa.h>
 #include "trm/subs.h"
 #include "trm/constants.h"
 #include "trm/date.h"

--- a/include/trm/position.h
+++ b/include/trm/position.h
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include <string>
+#include "sofa.h"
 #include "trm/subs.h"
 #include "trm/constants.h"
 #include "trm/date.h"

--- a/include/trm/time.h
+++ b/include/trm/time.h
@@ -3,6 +3,7 @@
 
 #include <string> 
 #include <ctime> 
+#include "sofa.h"
 #include "trm/date.h"
 #include "trm/subs.h"
 

--- a/include/trm/time.h
+++ b/include/trm/time.h
@@ -67,6 +67,8 @@ namespace Subs {
 	//! returns the decimal modified Julian day
 	double mjd() const;  
 
+	void hack_report() const;
+
 	//! returns the Julian epoch
 	double jepoch() const;  
 

--- a/include/trm/time.h
+++ b/include/trm/time.h
@@ -3,7 +3,7 @@
 
 #include <string> 
 #include <ctime> 
-#include "sofa.h"
+#include <sofa.h>
 #include "trm/date.h"
 #include "trm/subs.h"
 

--- a/src/date.cc
+++ b/src/date.cc
@@ -84,7 +84,7 @@ void Subs::Date::date(int& day_, int& month_, int& year_) const {
  * in question.
  */
 double Subs::Date::mjd() const {
-    return mjd_;
+return mjd_;
 }
 
 /** Set the date

--- a/src/date.cc
+++ b/src/date.cc
@@ -2,8 +2,8 @@
 
 #include <iomanip>
 #include <sstream>
-#include "slalib.h"
 #include "trm/subs.h"
+#include "sofa.h"
 
 int Subs::Date::print_method;
 
@@ -44,7 +44,7 @@ void Subs::Date::add_day(int nday){
 int Subs::Date::day() const{
     int d,m,y,status;
     double fd;
-    slaDjcl(double(mjd_)+0.1,&y,&m,&d,&fd,&status);
+	status = iauJd2cal(double(mjd_)+0.1, 50123.2, &y, &m, &d, &fd);
     return d;
 }
  
@@ -53,7 +53,7 @@ int Subs::Date::day() const{
 int Subs::Date::month() const{
     int d,m,y,status;
     double fd;
-    slaDjcl(double(mjd_)+0.1,&y,&m,&d,&fd,&status);
+    status = iauJd2cal(double(mjd_)+0.1, 50123.2, &y, &m, &d, &fd);
     return m;
 }
 
@@ -62,7 +62,7 @@ int Subs::Date::month() const{
 int Subs::Date::year() const{
     int d,m,y,status;
     double fd;
-    slaDjcl(double(mjd_)+0.1,&y,&m,&d,&fd,&status);
+    status = iauJd2cal(double(mjd_)+0.1, 50123.2, &y, &m, &d, &fd);
     return y;
 }
 
@@ -76,7 +76,7 @@ int Subs::Date::year() const{
 void Subs::Date::date(int& day_, int& month_, int& year_) const {
     int status;
     double fd;
-    slaDjcl(double(mjd_)+0.1,&year_,&month_,&day_,&fd,&status);
+	status = iauJd2cal(double(mjd_)+0.1, 50123.2, &year_, &month_, &day_, &fd);
 }
 
 /** Returns modified Julian day number,

--- a/src/date.cc
+++ b/src/date.cc
@@ -44,7 +44,7 @@ void Subs::Date::add_day(int nday){
 int Subs::Date::day() const{
     int d,m,y,status;
     double fd;
-	status = iauJd2cal(double(mjd_)+0.1, 50123.2, &y, &m, &d, &fd);
+	status = iauJd2cal(DMJ0, double(mjd_)+0.1,&y, &m, &d, &fd);
     return d;
 }
  
@@ -53,7 +53,7 @@ int Subs::Date::day() const{
 int Subs::Date::month() const{
     int d,m,y,status;
     double fd;
-    status = iauJd2cal(double(mjd_)+0.1, 50123.2, &y, &m, &d, &fd);
+    status = iauJd2cal(DMJ0, double(mjd_)+0.1, &y, &m, &d, &fd);
     return m;
 }
 
@@ -62,7 +62,7 @@ int Subs::Date::month() const{
 int Subs::Date::year() const{
     int d,m,y,status;
     double fd;
-    status = iauJd2cal(double(mjd_)+0.1, 50123.2, &y, &m, &d, &fd);
+    status = iauJd2cal(DMJ0, double(mjd_)+0.1, &y, &m, &d, &fd);
     return y;
 }
 
@@ -76,7 +76,7 @@ int Subs::Date::year() const{
 void Subs::Date::date(int& day_, int& month_, int& year_) const {
     int status;
     double fd;
-	status = iauJd2cal(double(mjd_)+0.1, 50123.2, &year_, &month_, &day_, &fd);
+	status = iauJd2cal(DMJ0, double(mjd_)+0.1,&year_, &month_, &day_, &fd);
 }
 
 /** Returns modified Julian day number,
@@ -99,7 +99,8 @@ void Subs::Date::set(int day_, int month_, int year_){
 	double mjd;
     valid_date(day_,month_,year_);
 	status = iauCal2jd(year_, month_, day_, &mjd, &mj);
-	mjd_ = int(mjd+mj+0.1);
+	
+	mjd_ = int(mj+0.1);
 }
 
 /** Set the date from a string

--- a/src/date.cc
+++ b/src/date.cc
@@ -3,7 +3,7 @@
 #include <iomanip>
 #include <sstream>
 #include "trm/subs.h"
-#include "sofa.h"
+
 
 int Subs::Date::print_method;
 

--- a/src/date.cc
+++ b/src/date.cc
@@ -83,7 +83,7 @@ void Subs::Date::date(int& day_, int& month_, int& year_) const {
  * i.e. JD - 2400000.5 at the start of the day 
  * in question.
  */
-int Subs::Date::mjd() const {
+double Subs::Date::mjd() const {
     return mjd_;
 }
 
@@ -98,9 +98,12 @@ void Subs::Date::set(int day_, int month_, int year_){
     double mj;
 	double mjd;
     valid_date(day_,month_,year_);
+	// mjd here is 2400000.5 and mj is the fractional part of the day
 	status = iauCal2jd(year_, month_, day_, &mjd, &mj);
 	
-	mjd_ = int(mj+0.1);
+	//mjd_ = int(mj+0.1);
+	// Set mjd_ internally to be the modified Julian day number (float)
+	mjd_ = mj;
 }
 
 /** Set the date from a string
@@ -229,7 +232,7 @@ std::string Subs::Date::day_of_week() const {
 
     std::string str;
 
-    switch((mjd() + 2) % 7){
+    switch((int(mjd()+0.1) + 2) % 7){
 	case 0:
 	    str = "Monday";
 	    break;
@@ -263,7 +266,7 @@ std::string Subs::Date::day_of_week() const {
  * \return Integer from 0 to 6, 0 = Sunday.
  */
 int Subs::Date::int_day_of_week() const {
-    return (mjd() + 3) % 7;
+    return (int(mjd()+0.1) + 3) % 7;
 }
 
 /** Reads a date stored in binary format

--- a/src/date.cc
+++ b/src/date.cc
@@ -44,7 +44,7 @@ void Subs::Date::add_day(int nday){
 int Subs::Date::day() const{
     int d,m,y,status;
     double fd;
-	status = iauJd2cal(DMJ0, double(mjd_)+0.1,&y, &m, &d, &fd);
+	status = iauJd2cal(MJD0, double(mjd_)+0.1,&y, &m, &d, &fd);
     return d;
 }
  
@@ -53,7 +53,7 @@ int Subs::Date::day() const{
 int Subs::Date::month() const{
     int d,m,y,status;
     double fd;
-    status = iauJd2cal(DMJ0, double(mjd_)+0.1, &y, &m, &d, &fd);
+    status = iauJd2cal(MJD0, double(mjd_)+0.1, &y, &m, &d, &fd);
     return m;
 }
 
@@ -62,7 +62,7 @@ int Subs::Date::month() const{
 int Subs::Date::year() const{
     int d,m,y,status;
     double fd;
-    status = iauJd2cal(DMJ0, double(mjd_)+0.1, &y, &m, &d, &fd);
+    status = iauJd2cal(MJD0, double(mjd_)+0.1, &y, &m, &d, &fd);
     return y;
 }
 
@@ -76,7 +76,7 @@ int Subs::Date::year() const{
 void Subs::Date::date(int& day_, int& month_, int& year_) const {
     int status;
     double fd;
-	status = iauJd2cal(DMJ0, double(mjd_)+0.1,&year_, &month_, &day_, &fd);
+	status = iauJd2cal(MJD0, double(mjd_)+0.1,&year_, &month_, &day_, &fd);
 }
 
 /** Returns modified Julian day number,

--- a/src/date.cc
+++ b/src/date.cc
@@ -96,9 +96,10 @@ int Subs::Date::mjd() const {
 void Subs::Date::set(int day_, int month_, int year_){
     int status;
     double mj;
+	double mjd;
     valid_date(day_,month_,year_);
-    slaCldj(year_, month_, day_, &mj, &status);
-    mjd_ = int(mj+0.1);
+	status = iauCal2jd(year_, month_, day_, &mjd, &mj);
+	mjd_ = int(mjd+mj+0.1);
 }
 
 /** Set the date from a string

--- a/src/position.cc
+++ b/src/position.cc
@@ -309,7 +309,12 @@ Subs::Altaz Subs::Position::altaz(const Time& time, const Telescope& tel) const 
     temp.alt_true = 90.-360.*zvac/Constants::TWOPI;
     temp.alt_obs  = 90.-360.*zob/Constants::TWOPI;
     temp.az       = 360.*aob/Constants::TWOPI;
-    temp.airmass  = slaAirmas(zob);
+    // rewriting slaAirmas by hand as it is not in SOFA
+    #include <cmath>
+
+
+    double SECZM1 = 1.0 / (cos(std::min(1.52, std::abs(zob)))) - 1.0;
+    temp.airmass  = 1.0 + SECZM1 * (0.9981833 - SECZM1 * (0.002875 + 0.0008083 * SECZM1));
 
     // Compute pa
     temp.pa = 360.*iauHd2pa(hob,pos.decr(),tel.latituder())/Constants::TWOPI;

--- a/src/position.cc
+++ b/src/position.cc
@@ -4,7 +4,7 @@
 #include "trm/subs.h"
 #include "trm/telescope.h"
 #include "trm/position.h"
-#include "slalib.h"
+#include "sofa.h"
 
 /** Constructs a Position of arbitrary RA and Dec (proper motion, parallax and radial velocity
  * all set = 0)
@@ -147,8 +147,9 @@ void Subs::Position::update(double epch){
     if(epch == epoch()) return;
 
     // Apply proper motion; space velocity to go from epoch() to epch
-    double ra, dec;
-    slaPm(rar(), decr(), pmrar(), pmdecr(), parallax(), rv(), epoch(), epch, &ra, &dec); 
+    double ra, dec, pmr, pmd, px, rv_;
+    //slaPm(rar(), decr(), pmrar(), pmdecr(), parallax(), rv(), epoch(), epch, &ra, &dec);
+    iauPmsafe(rar(), decr(), pmrar(), pmdecr(), parallax(), rv(), MJD0, epoch(), MJD0, epch, &ra, &dec, &pmr, &pmd, &px, &rv_);
     set_radec(ra, dec);
     epoch() = epch;
 

--- a/src/position.cc
+++ b/src/position.cc
@@ -162,7 +162,8 @@ void Subs::Position::update(double epch){
 
 Subs::Vec3 Subs::Position::vect() const {
     double v[3];
-    slaDcs2c(rar(), decr(), v); 
+    //slaDcs2c(rar(), decr(), v);
+    iauS2c(rar(), decr(), v);
     Subs::Vec3 vec(v);
     return Subs::Vec3(v);
 }

--- a/src/position.cc
+++ b/src/position.cc
@@ -146,10 +146,12 @@ void Subs::Position::update(double epch){
     if(epch == epoch()) return;
 
     // Apply proper motion; space velocity to go from epoch() to epch
-    double ra, dec, pmr, pmd, px, rv_;
+    double ra, dec, _pmr, _pmd, _px, _rv_;
     //slaPm(rar(), decr(), pmrar(), pmdecr(), parallax(), rv(), epoch(), epch, &ra, &dec);
-    iauPmsafe(rar(), decr(), pmrar(), pmdecr(), parallax(), rv(), MJD0, epoch(), MJD0, epch, &ra, &dec, &pmr, &pmd, &px, &rv_);
+    iauPmsafe(rar(), decr(), pmrar(), pmdecr(), parallax(), rv(), MJD0, epoch(), MJD0, epch, &ra, &dec, &_pmr, &_pmd, &_px, &_rv_);
     set_radec(ra, dec);
+    // ra() = _ra;
+    // dec() = _dec;
     epoch() = epch;
 
 }

--- a/src/position.cc
+++ b/src/position.cc
@@ -4,7 +4,6 @@
 #include "trm/subs.h"
 #include "trm/telescope.h"
 #include "trm/position.h"
-#include "sofa.h"
 
 /** Constructs a Position of arbitrary RA and Dec (proper motion, parallax and radial velocity
  * all set = 0)

--- a/src/time.cc
+++ b/src/time.cc
@@ -302,6 +302,7 @@ Subs::Vec3 Subs::Time::earth_pos_bar(const Telescope& tel) const {
     iauRxp(rnpb, pv[0], pv[0]);
 
     Vec3 pextra(pv[0]);
+    position *= Constants::AU;
     position += pextra;
 
     return position;
@@ -379,7 +380,9 @@ Subs::Vec3 Subs::Time::earth_pos_hel(const Telescope& tel) const {
     iauRxp(rnpb, pv[0], pv[0]);
 
     Vec3 pextra(pv[0]);
+    position *= Constants::AU;
     position += pextra;
+   
 
     return position;
 }
@@ -455,6 +458,7 @@ void Subs::Time::earth(const Telescope& tel, Vec3& ph, Vec3& vh, Vec3& pb, Vec3&
     // iauPnm80()
     iauTr(rnpb, rnpb);
     iauRxpv(rnpb, pv, pv);
+
     Vec3 padd(pv[0]), vadd(pv[1]);
     //get earth position and velocity note returns in AU and Pvtob returns in m
     double pvh[2][3];

--- a/src/time.cc
+++ b/src/time.cc
@@ -127,8 +127,9 @@ double Subs::Time::dtt() const {
     double tt1, tt2;
     // go from atomic time to TT
     status = iauTaitt(at1, at2, &tt1, &tt2);
-
-    return (dj1+dj2) - (tt1+tt2);
+    // convert to seconds
+    return tt2*86400.0 - dj2*86400.0;
+    //return tt2;
 }
 
 /** Returns Terestial Time (TT) in the form of MJD

--- a/src/time.cc
+++ b/src/time.cc
@@ -158,8 +158,11 @@ double Subs::Time::dtdb(const Subs::Telescope& tel) const {
     //v  *= Constants::AU/1000.0; // km north of equator
     //return slaRcc(tt(),hour()/24.,wl,u,v);
 
+    // define the reference ellipsoid
+    int n = 1;
+
     // SOFA version
-    double* xyz[3];
+    double xyz[3];
     iauGd2gc(n, tel.longituder(), tel.latituder(), tel.height(), xyz);
     // xyz is a geocentric position vector in metres
 
@@ -175,10 +178,10 @@ double Subs::Time::dtdb(const Subs::Telescope& tel) const {
     // u = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1])/1000.0
     // v = xyz[2]/1000.0
 
-    double u = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1])/1000.0;
-    double v = xyz[2]/1000.0;
+    double u = sqrt(xyz[0] * xyz[0] + xyz[1] * xyz[1])/1000.0;
+    double v = xyz[2] / 1000.0;
     // to Barycentric Dynamical Time offset from TT
-    return iauDtdb(tt(), 0.0, hour()/24., elong, u, v);
+    return iauDtdb(tt(), 0.0, hour()/24., tel.longituder(), u, v);
 
 }
 
@@ -200,11 +203,13 @@ double Subs::Time::tdb(const Subs::Telescope& tel) const {
     // double tti = tt();
     // return tti + slaRcc( tti, hour()/24., wl, u, v)/86400.0;
 
+    // define the reference ellipsoid
+    int n = 1;
 
     // // SOFA version
-    double* xyz[3];
+    double xyz[3];
     iauGd2gc(n, tel.longituder(), tel.latituder(), tel.height(), xyz);
-    xyz is a geocentric position vector in metres
+    //xyz is a geocentric position vector in metres
 
     // the following function iauDttdb takes the following arguments
     // d1, d2 are the MJDs of the date
@@ -218,11 +223,11 @@ double Subs::Time::tdb(const Subs::Telescope& tel) const {
     // u = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1])/1000.0
     // v = xyz[2]/1000.0
 
-    double u = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1])/1000.0;
-    double v = xyz[2]/1000.0;
+    double u = sqrt(xyz[0] * xyz[0] + xyz[1] * xyz[1])/1000.0;
+    double v = xyz[2] / 1000.0;
     // to Barycentric Dynamical Time
     double tti = tt();
-    return tti + iauDtdb(tt(), 0.0, hour()/24., elong, u, v)/86400.0;
+    return tti + iauDtdb(tt(), 0.0, hour()/24., tel.longituder(), u, v)/86400.0;
 }
 
 /** Computes the position of the observatory in barycentric

--- a/src/time.cc
+++ b/src/time.cc
@@ -97,7 +97,7 @@ Subs::Time::HMS Subs::Time::hms() const{
  * \return Modified Julian dates are Julian dates - 2400000.5
  */
 double Subs::Time::mjd() const{
-    return Date::mjd() + hour()/24.
+    return Date::mjd() + hour()/24.;
 }
 
 /** Returns the Julian epoch corresponding to the Time

--- a/src/time.cc
+++ b/src/time.cc
@@ -6,7 +6,6 @@
 #include "trm/time.h"
 #include "trm/vec3.h"
 #include "trm/telescope.h"
-#include "sofa.h"
 
 Subs::Time::Time(int day_, Date::Month month_, int year_, double hour) : Date(day_,month_,year_) {
 

--- a/src/time.cc
+++ b/src/time.cc
@@ -177,7 +177,7 @@ double Subs::Time::dtdb(const Subs::Telescope& tel) const {
 
     double u = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1])/1000.0;
     double v = xyz[2]/1000.0;
-    // to Barycentric Dynamical Time
+    // to Barycentric Dynamical Time offset from TT
     return iauDtdb(tt(), 0.0, hour()/24., elong, u, v);
 
 }
@@ -192,14 +192,37 @@ double Subs::Time::tdb(const Subs::Telescope& tel) const {
     // Switched back to pure SLA. Note that old
     // wl had reverse sign, I assume because of the SOFA
     // routine used in place of slaRCC. TRM, 23/11/2007
-    double wl, u, v;
-    slaGeoc( tel.latituder(), tel.height(), &u, &v);
-    wl  = -tel.longituder(); // Longitude, radians west
-    u  *= Constants::AU/1000.0; // km from spin axis
-    v  *= Constants::AU/1000.0; // km north of equator
-    double tti = tt();
-    return tti + slaRcc( tti, hour()/24., wl, u, v)/86400.0;
+    // double wl, u, v;
+    // slaGeoc( tel.latituder(), tel.height(), &u, &v);
+    // wl  = -tel.longituder(); // Longitude, radians west
+    // u  *= Constants::AU/1000.0; // km from spin axis
+    // v  *= Constants::AU/1000.0; // km north of equator
+    // double tti = tt();
+    // return tti + slaRcc( tti, hour()/24., wl, u, v)/86400.0;
 
+
+    // // SOFA version
+    double* xyz[3];
+    iauGd2gc(n, tel.longituder(), tel.latituder(), tel.height(), xyz);
+    xyz is a geocentric position vector in metres
+
+    // the following function iauDttdb takes the following arguments
+    // d1, d2 are the MJDs of the date
+    // elong is the longitude of the Telescope in radians
+    // u is the distance of the telescope from the Earth's spin axis in km
+    // v is the distance of the telescope from the Earth's equatorial
+    //   plane in km
+
+    // so we need to convert the geocentric position vector to km
+    // elong == tel.longituder() in radians (east positive)
+    // u = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1])/1000.0
+    // v = xyz[2]/1000.0
+
+    double u = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1])/1000.0;
+    double v = xyz[2]/1000.0;
+    // to Barycentric Dynamical Time
+    double tti = tt();
+    return tti + iauDtdb(tt(), 0.0, hour()/24., elong, u, v)/86400.0;
 }
 
 /** Computes the position of the observatory in barycentric

--- a/src/time.cc
+++ b/src/time.cc
@@ -274,6 +274,23 @@ Subs::Vec3 Subs::Time::earth_pos_bar(const Telescope& tel) const {
 
     return position;
 
+
+    //SOFA version
+    double td = tdb(tel);
+    double tt = tt()
+    double pvh[2][3];
+    double pvb[2][3];
+
+    int status;
+    status = iauEpv00(MJD0, td, pvh, pvb);
+
+    Vec3 position(pvb[0]);
+
+    double last = iauGmst06(MJD0, td, MJD0, tt) + tel.longituder() + iauEqeq94(MJD0, td);
+    double pv[6];
+
+    iauPvtob()
+
 }
 
 /** Computes the position and velocity of the Earth in heliocentric coordinates. 

--- a/src/time.cc
+++ b/src/time.cc
@@ -100,6 +100,10 @@ double Subs::Time::mjd() const{
     return Date::mjd() + hour()/24.;
 }
 
+void hack_report() {
+    std::cout << "Time::hack_report: leap second hack not in effect" << std::endl;
+};
+
 /** Returns the Julian epoch corresponding to the Time
  */
 double Subs::Time::jepoch() const{

--- a/src/time.cc
+++ b/src/time.cc
@@ -107,9 +107,9 @@ double Subs::Time::mjd() const{
 
 double Subs::Time::jepoch() const{
     // Back to sla 25/11/07, TRM
-    float dj1, dj2;
-    dj1 = mjd();
-    dj2 = 50123.2;
+    double dj1, dj2;
+    dj1 = MJD0;
+    dj2 = mjd();
     return iauEpj(dj1, dj2);
 }
 
@@ -118,8 +118,18 @@ double Subs::Time::jepoch() const{
  * \return Returns TT-UTC in seconds
  */
 double Subs::Time::dtt() const {
-    // Changed to pure SLA 23/11/2007 TRM
-    return slaDtt(mjd());
+    int status;
+    double dj1, dj2;
+    dj1 = MJD0;
+    dj2 = mjd();
+    double at1, at2;
+    // go via atomic time
+    status = iauUtctai(dj1, dj2, at1, at2);
+    double tt1, tt2;
+    // go from atomic time to TT
+    status = iauTaitt(at1, at2, tt1, tt2);
+
+    return (dj1+dj2) - (tt1+tt2);
 }
 
 /** Returns Terestial Time (TT) in the form of MJD
@@ -128,7 +138,8 @@ double Subs::Time::dtt() const {
 double Subs::Time::tt() const {
     // Changed to pure SLA 23/11/2007 TRM
     double mj = this->mjd();
-    return mj + slaDtt(mj)/86400.;
+    double delta_t = dtt();
+    return mj + delta_t/86400.;
 }
 
 /** Returns Barycentric Dynamical Time (TDB) minus TT in seconds

--- a/src/time.cc
+++ b/src/time.cc
@@ -96,14 +96,12 @@ Subs::Time::HMS Subs::Time::hms() const{
  * is considered.
  * \return Modified Julian dates are Julian dates - 2400000.5
  */
-
 double Subs::Time::mjd() const{
-    return Date::mjd() + hour()/24.;
+    return Date::mjd() + hour()/24.
 }
 
 /** Returns the Julian epoch corresponding to the Time
  */
-
 double Subs::Time::jepoch() const{
     // Back to sla 25/11/07, TRM
     double dj1, dj2;

--- a/src/time.cc
+++ b/src/time.cc
@@ -3,10 +3,10 @@
 #include <sstream>
 #include "trm/subs.h"
 #include "trm/constants.h"
-#include "slalib.h"
 #include "trm/time.h"
 #include "trm/vec3.h"
 #include "trm/telescope.h"
+#include "sofa.h"
 
 Subs::Time::Time(int day_, Date::Month month_, int year_, double hour) : Date(day_,month_,year_) {
 
@@ -107,7 +107,10 @@ double Subs::Time::mjd() const{
 
 double Subs::Time::jepoch() const{
     // Back to sla 25/11/07, TRM
-    return slaEpj(mjd());
+    float dj1, dj2;
+    dj1 = mjd();
+    dj2 = 50123.2;
+    return iauEpj(dj1, dj2);
 }
 
 

--- a/src/time.cc
+++ b/src/time.cc
@@ -100,7 +100,7 @@ double Subs::Time::mjd() const{
     return Date::mjd() + hour()/24.;
 }
 
-void hack_report() {
+void Subs::Time::hack_report() const{
     std::cout << "Time::hack_report: leap second hack not in effect" << std::endl;
 };
 

--- a/steps-to-make.sh
+++ b/steps-to-make.sh
@@ -1,0 +1,30 @@
+brew install pcre
+wget http://www.iausofa.org/2023_1011_C/sofa_c-20231011.tar.gz
+wget ftp://ftp.astro.caltech.edu/pub/pgplot/pgplot5.2.tar.gz
+
+tar -xvzf sofa_c-20231011.tar.gz
+
+brew install automake
+brew install libtool
+
+#This makes the libsofa_c.a we will need later
+cd sofa/VERSION/c/src
+make
+sudo mkdir /usr/local/lib/sofa
+cp *.o *.a *.h /usr/local/lib/sofa/
+# I think the sofa bit would be better placed in the usr/src directory
+
+
+# Make libcpgplot.a
+# On mac, do this
+http://mingus.as.arizona.edu/~bjw/software/pgplot_fix.html
+# Otherwise follow the instructions in the README for PGPLOT
+
+brew install pkg-config
+pkg-config --libs --cflags /opt/homebrew/Cellar/pcre/*/lib/pkgconfig/libpcrecpp.pc 
+
+export CPPFLAGS="-I/opt/homebrew/Cellar/pcre/8.45/include -I/usr/local/lib/pgplot -I/usr/local/lib/sofa"
+export LDFLAGS="-L/opt/homebrew/Cellar/pcre/8.45/lib -L/usr/local/lib/pgplot -L/usr/local/lib/sofa"
+
+
+./configure

--- a/steps-to-make.sh
+++ b/steps-to-make.sh
@@ -52,8 +52,10 @@ export LDFLAGS="-L$HOME/lib/"
 
 ./bootstrap
 
-./configure
+./configure -prefix="$HOME"
 
 make
+
+make check
 
 make install

--- a/steps-to-make.sh
+++ b/steps-to-make.sh
@@ -32,7 +32,11 @@ export LDFLAGS="-L/opt/homebrew/Cellar/pcre/8.45/lib -L/usr/local/lib/pgplot -L/
 ./bootstrap
 ./configure
 
+make
 
+make check
+
+make install
 
 # On SCRTP, do this
 

--- a/steps-to-make.sh
+++ b/steps-to-make.sh
@@ -10,10 +10,12 @@ brew install libtool
 #This makes the libsofa_c.a we will need later
 cd sofa/VERSION/c/src
 make
+# on mac
 sudo mkdir /usr/local/lib/sofa
 cp *.o *.a *.h /usr/local/lib/sofa/
 # I think the sofa bit would be better placed in the usr/src directory
-
+# on scrtpc
+make test
 
 # Make libcpgplot.a
 # On mac, do this
@@ -23,8 +25,35 @@ http://mingus.as.arizona.edu/~bjw/software/pgplot_fix.html
 brew install pkg-config
 pkg-config --libs --cflags /opt/homebrew/Cellar/pcre/*/lib/pkgconfig/libpcrecpp.pc 
 
+# on mac, do this
 export CPPFLAGS="-I/opt/homebrew/Cellar/pcre/8.45/include -I/usr/local/lib/pgplot -I/usr/local/lib/sofa"
 export LDFLAGS="-L/opt/homebrew/Cellar/pcre/8.45/lib -L/usr/local/lib/pgplot -L/usr/local/lib/sofa"
-
+# on scrtpc, do this
+export CPPFLAGS="-I/home/csc/pfstcb/include/"
+export LDFLAGS="-L/home/csc/pfstcb/lib/"
 
 ./configure
+
+
+
+# On SCRTC, do this
+
+module load GCCcore/11.3.0 Autotools/20220317 libtool/2.4.7 PCRE/8.45 PGPLOT/5.2.2
+
+wget http://www.iausofa.org/2023_1011_C/sofa_c-20231011.tar.gz
+
+cd sofa/VERSION/c/src
+make
+make test
+
+# on scrtpc, do this
+export CPPFLAGS="-I$HOME/include/"
+export LDFLAGS="-L$HOME/lib/"
+
+./bootstrap
+
+./configure
+
+make
+
+make install

--- a/steps-to-make.sh
+++ b/steps-to-make.sh
@@ -21,7 +21,7 @@ make test
 # On mac, do this
 http://mingus.as.arizona.edu/~bjw/software/pgplot_fix.html
 # Otherwise follow the instructions in the README for PGPLOT
-
+cd 
 brew install pkg-config
 pkg-config --libs --cflags /opt/homebrew/Cellar/pcre/*/lib/pkgconfig/libpcrecpp.pc 
 
@@ -36,19 +36,19 @@ export LDFLAGS="-L/home/csc/pfstcb/lib/"
 
 
 
-# On SCRTC, do this
+# On SCRTP, do this
 
-module load GCCcore/11.3.0 Autotools/20220317 libtool/2.4.7 PCRE/8.45 PGPLOT/5.2.2
+module load GCCcore/11.3.0 GCC/11.3.0 Autotools/20220317 libtool/2.4.7 PCRE/8.45 PGPLOT/5.2.2 SOFA_C/19
 
-wget http://www.iausofa.org/2023_1011_C/sofa_c-20231011.tar.gz
-
-cd sofa/VERSION/c/src
-make
-make test
+# wget http://www.iausofa.org/2023_1011_C/sofa_c-20231011.tar.gz
+# tar -xvzf sofa_c-20231011.tar.gz
+# cd sofa/VERSION/c/src
+# make
+# make test
 
 # on scrtpc, do this
-export CPPFLAGS="-I$HOME/include/"
-export LDFLAGS="-L$HOME/lib/"
+export CPPFLAGS="-I$HOME/include/ -fPIC"
+export LDFLAGS="-L$HOME/lib/ -fPIC"
 
 ./bootstrap
 

--- a/steps-to-make.sh
+++ b/steps-to-make.sh
@@ -28,10 +28,8 @@ pkg-config --libs --cflags /opt/homebrew/Cellar/pcre/*/lib/pkgconfig/libpcrecpp.
 # on mac, do this
 export CPPFLAGS="-I/opt/homebrew/Cellar/pcre/8.45/include -I/usr/local/lib/pgplot -I/usr/local/lib/sofa"
 export LDFLAGS="-L/opt/homebrew/Cellar/pcre/8.45/lib -L/usr/local/lib/pgplot -L/usr/local/lib/sofa"
-# on scrtpc, do this
-export CPPFLAGS="-I/home/csc/pfstcb/include/"
-export LDFLAGS="-L/home/csc/pfstcb/lib/"
 
+./bootstrap
 ./configure
 
 


### PR DESCRIPTION
This issue details the code changes: https://github.com/WarwickRSE/cpp-subs/issues/1

Other changes:
The addition of a steps-to-make file which shows how to build on the different systems I was using (Mac, apple silicon) and SCRTP. 
Updates to the autoconf file configure.ac to remove sla lib and include SOFA

@dquigley533 This needs testing before it goes live if there are no mistakes it would be a minor miracle. I think it would be best if we roped in an astronomer who has used this code who may have some simple calibration checks that will assure the code still produces the same answers. 

For this we will need to have both the old (sla) and new (sofa) cpp-subs running on the systems.